### PR TITLE
support ssh configuration logic through sshd_config.d on google backend

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -154,7 +154,9 @@ const googleStartupScript = `
 echo root:%s | chpasswd
 
 sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
-test -d /etc/ssh/sshd_config.d && echo -e 'PermitRootLogin=yes\nPasswordAuthentication=yes' > /etc/ssh/sshd_config.d/00-spread-settings.conf
+sed -i 's/^PermitRootLogin=/#PermitRootLogin=/g' /etc/ssh/sshd_config.d/* || true
+sed -i 's/^PasswordAuthentication=/#PasswordAuthentication=/g' /etc/ssh/sshd_config.d/* || true
+test -d /etc/ssh/sshd_config.d && echo -e 'PermitRootLogin=yes\nPasswordAuthentication=yes' > /etc/ssh/sshd_config.d/00-spread.conf
 
 pkill -o -HUP sshd || true
 

--- a/spread/google.go
+++ b/spread/google.go
@@ -154,6 +154,7 @@ const googleStartupScript = `
 echo root:%s | chpasswd
 
 sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+test -d /etc/ssh/sshd_config.d && echo -e 'PermitRootLogin=yes\nPasswordAuthentication=yes' > /etc/ssh/sshd_config.d/00-spread-settings.conf
 
 pkill -o -HUP sshd || true
 


### PR DESCRIPTION
Some images (like ubuntu kinetic) override the ssh configuration by using the new `sshd_config.d` directory and no longer ship a `/etc/sshd_config` file.

This change makes sure these systems will have the needed shell configuration to run spread.

As the first value wins, we need to use `00-` for the configuration file to make sure this is the first file with that config