### PR TITLE
google: mark cache as ready after it got populated

### DIFF
--- a/spread/client_test.go
+++ b/spread/client_test.go
@@ -16,13 +16,13 @@ type clientSuite struct{}
 var _ = Suite(&clientSuite{})
 
 func (s *clientSuite) TestDialOnReboot(c *C) {
-	restore := spread.MockSshDial(func(network, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
+	restore := spread.FakeSshDial(func(network, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
 		time.Sleep(1 * time.Second)
 		return nil, fmt.Errorf("cannot connect")
 	})
 	defer restore()
 
-	cli := spread.MockClient()
+	cli := spread.FakeClient()
 	spread.SetWarnTimeout(cli, 50*time.Millisecond)
 	spread.SetKillTimeout(cli, 100*time.Millisecond)
 

--- a/spread/export_test.go
+++ b/spread/export_test.go
@@ -1,6 +1,7 @@
 package spread
 
 import (
+	"net/http"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -38,3 +39,19 @@ func MockSshDial(f func(network, addr string, config *ssh.ClientConfig) (*ssh.Cl
 }
 
 var QemuCmd = qemuCmd
+
+func NewGoogleProviderForTesting(mockApiURL string, p *Project, b *Backend, o *Options) *googleProvider {
+	provider := Google(p, b, o)
+	ggl := provider.(*googleProvider)
+	ggl.apiURL = mockApiURL
+	ggl.keyChecked = true
+	ggl.client = &http.Client{}
+
+	return ggl
+}
+
+func (p *googleProvider) ProjectImages(project string) ([]googleImage, error) {
+	return p.projectImages(project)
+}
+
+type GoogleImage = googleImage

--- a/spread/export_test.go
+++ b/spread/export_test.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func MockClient() *Client {
+func FakeClient() *Client {
 	config := &ssh.ClientConfig{
 		User:    "mock",
 		Timeout: 10 * time.Second,
@@ -30,7 +30,7 @@ func SetWarnTimeout(cli *Client, warnTimeout time.Duration) {
 	cli.warnTimeout = warnTimeout
 }
 
-func MockSshDial(f func(network, addr string, config *ssh.ClientConfig) (*ssh.Client, error)) (restore func()) {
+func FakeSshDial(f func(network, addr string, config *ssh.ClientConfig) (*ssh.Client, error)) (restore func()) {
 	oldSshDial := sshDial
 	sshDial = f
 	return func() {
@@ -40,18 +40,18 @@ func MockSshDial(f func(network, addr string, config *ssh.ClientConfig) (*ssh.Cl
 
 var QemuCmd = qemuCmd
 
-func NewGoogleProviderForTesting(mockApiURL string, p *Project, b *Backend, o *Options) *googleProvider {
+func FakeGoogleProvider(mockApiURL string, p *Project, b *Backend, o *Options) Provider {
 	provider := Google(p, b, o)
 	ggl := provider.(*googleProvider)
 	ggl.apiURL = mockApiURL
 	ggl.keyChecked = true
 	ggl.client = &http.Client{}
 
-	return ggl
+	return provider
 }
 
-func (p *googleProvider) ProjectImages(project string) ([]googleImage, error) {
-	return p.projectImages(project)
+func ProjectImages(provider Provider, project string) ([]googleImage, error) {
+	return provider.(*googleProvider).projectImages(project)
 }
 
 type GoogleImage = googleImage

--- a/spread/google.go
+++ b/spread/google.go
@@ -31,6 +31,8 @@ func Google(p *Project, b *Backend, o *Options) Provider {
 		options: o,
 
 		imagesCache: make(map[string]*googleImagesCache),
+
+		apiURL: "https://www.googleapis.com",
 	}
 }
 
@@ -50,6 +52,8 @@ type googleProvider struct {
 	keyErr     error
 
 	imagesCache map[string]*googleImagesCache
+
+	apiURL string
 }
 
 type googleServer struct {
@@ -899,7 +903,7 @@ func (p *googleProvider) dofl(method, subpath string, params interface{}, result
 
 	<-googleThrottle
 
-	url := "https://www.googleapis.com"
+	url := p.apiURL
 	if flags&noPathPrefix == 0 {
 		url += "/compute/v1/projects/" + p.gproject() + subpath
 	} else {

--- a/spread/google.go
+++ b/spread/google.go
@@ -369,6 +369,7 @@ func (p *googleProvider) projectImages(project string) ([]googleImage, error) {
 			Terms:   toTerms(item.Description),
 		})
 	}
+	cache.ready = true
 
 	return cache.images, err
 }

--- a/spread/google_test.go
+++ b/spread/google_test.go
@@ -1,0 +1,69 @@
+package spread_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/snapcore/spread/spread"
+
+	. "gopkg.in/check.v1"
+)
+
+type googleSuite struct{}
+
+var _ = Suite(&googleSuite{})
+
+func (s *googleSuite) TestImagesCache(c *C) {
+	n := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.URL.Path, Equals, "/compute/v1/projects/snapd/global/images")
+			w.Write([]byte(`
+                {
+                    "items": [{"status":"READY","name":"ubuntu-1910-64-v20190826", "description":"ubuntu-19.10-64"}, {"status":"READY","name":"ubuntu-1904-64-v20190726", "description":"ubuntu-19.04-64"}]
+                }
+                `))
+		case 1:
+			c.Check(r.URL.Path, Equals, "/compute/v1/projects/other-project/global/images")
+			w.Write([]byte(`
+                {
+                    "items": [{"status":"READY","name":"ubuntu-2004-64-v20190826", "description":"ubuntu-19.10-64"}]
+                }
+                `))
+		default:
+			c.Fatalf("unexpected number of requests")
+		}
+		n++
+	}))
+	defer mockServer.Close()
+
+	g := spread.NewGoogleProviderForTesting(mockServer.URL, nil, nil, nil)
+	c.Assert(g, NotNil)
+
+	// Request the project images
+	images, err := g.ProjectImages("snapd")
+	c.Assert(err, IsNil)
+	c.Assert(images, HasLen, 2)
+	c.Check(images, DeepEquals, []spread.GoogleImage{
+		{"snapd", "ubuntu-1910-64-v20190826", "", []string{"ubuntu", "19.10", "64"}},
+		{"snapd", "ubuntu-1904-64-v20190726", "", []string{"ubuntu", "19.04", "64"}},
+	})
+	c.Check(n, Equals, 1)
+
+	// do it again, now it comes from the cache
+	images, err = g.ProjectImages("snapd")
+	c.Assert(err, IsNil)
+	c.Assert(images, HasLen, 2)
+	c.Check(images, DeepEquals, []spread.GoogleImage{
+		{"snapd", "ubuntu-1910-64-v20190826", "", []string{"ubuntu", "19.10", "64"}},
+		{"snapd", "ubuntu-1904-64-v20190726", "", []string{"ubuntu", "19.04", "64"}},
+	})
+	c.Check(n, Equals, 1)
+
+	// again, this time for another project
+	images, err = g.ProjectImages("other-project")
+	c.Assert(err, IsNil)
+	c.Assert(images, HasLen, 1)
+	c.Check(n, Equals, 2)
+}

--- a/spread/google_test.go
+++ b/spread/google_test.go
@@ -32,7 +32,7 @@ func (s *googleSuite) TestImagesCache(c *C) {
                 }
                 `))
 		default:
-			c.Fatalf("unexpected number of requests")
+			c.Errorf("unexpected number of requests")
 		}
 		n++
 	}))

--- a/spread/google_test.go
+++ b/spread/google_test.go
@@ -38,11 +38,11 @@ func (s *googleSuite) TestImagesCache(c *C) {
 	}))
 	defer mockServer.Close()
 
-	g := spread.NewGoogleProviderForTesting(mockServer.URL, nil, nil, nil)
+	g := spread.FakeGoogleProvider(mockServer.URL, nil, nil, nil)
 	c.Assert(g, NotNil)
 
 	// Request the project images
-	images, err := g.ProjectImages("snapd")
+	images, err := spread.ProjectImages(g, "snapd")
 	c.Assert(err, IsNil)
 	c.Assert(images, HasLen, 2)
 	c.Check(images, DeepEquals, []spread.GoogleImage{
@@ -52,7 +52,7 @@ func (s *googleSuite) TestImagesCache(c *C) {
 	c.Check(n, Equals, 1)
 
 	// do it again, now it comes from the cache
-	images, err = g.ProjectImages("snapd")
+	images, err = spread.ProjectImages(g, "snapd")
 	c.Assert(err, IsNil)
 	c.Assert(images, HasLen, 2)
 	c.Check(images, DeepEquals, []spread.GoogleImage{
@@ -62,7 +62,7 @@ func (s *googleSuite) TestImagesCache(c *C) {
 	c.Check(n, Equals, 1)
 
 	// again, this time for another project
-	images, err = g.ProjectImages("other-project")
+	images, err = spread.ProjectImages(g, "other-project")
 	c.Assert(err, IsNil)
 	c.Assert(images, HasLen, 1)
 	c.Check(n, Equals, 2)


### PR DESCRIPTION
The googleImagesCache is currently not marked `ready`. This means while it is correctly build it is not used in subsequent calls to projectImages(). This commit set the cache to ready after it got populated.

The first commit fixes the issue, the second adds the test that shows the behavior. Happy to talk about the test more, it makes google a bit easier to test but maybe you prefer a different approach :)

