### PR TITLE
backends: LXD: don't hardcode eth0

### DIFF
--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -443,9 +443,14 @@ func (p *lxdProvider) address(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	for _, addr := range sjson.State.Network["eth0"].Addresses {
-		if addr.Family == "inet" && addr.Address != "" {
-			return addr.Address, nil
+	for intf, network := range sjson.State.Network {
+		if intf == "lo" {
+			continue
+		}
+		for _, addr := range network.Addresses {
+			if addr.Family == "inet" && addr.Address != "" {
+				return addr.Address, nil
+			}
 		}
 	}
 	return "", &lxdNoAddrError{name}

--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -443,11 +443,11 @@ func (p *lxdProvider) address(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	for intf, network := range sjson.State.Network {
-		if intf == "lo" {
+	for ifacename, ifaceconf := range sjson.State.Network {
+		if ifacename == "lo" {
 			continue
 		}
-		for _, addr := range network.Addresses {
+		for _, addr := range ifaceconf.Addresses {
 			if addr.Family == "inet" && addr.Address != "" {
 				return addr.Address, nil
 			}


### PR DESCRIPTION
With the ubuntu-22.04 image, the network interface seems to be sometimes named "enp5s0" instead of "eth0". To be compatible with both old and new releases, consider any non-loopback interface viable for retrieving an IP address.