### PR TITLE
backends: LXD: fix SSH login for ubuntu-22.04

### DIFF
--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -482,7 +482,8 @@ func (p *lxdProvider) serverJSON(name string) (*lxdServerJSON, error) {
 func (p *lxdProvider) tuneSSH(name string) error {
 	cmds := [][]string{
 		{"sed", "-i", `s/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/`, "/etc/ssh/sshd_config"},
-		{"/bin/bash", "-c", `sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config.d/* || true`},
+		{"/bin/bash", "-c", `sed -i 's/^\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/# COMMENTED OUT BY SPREAD: \0/' /etc/ssh/sshd_config.d/* || true`},
+		{"/bin/bash", "-c", `test -d /etc/ssh/sshd_config.d && echo -e 'PermitRootLogin=yes\nPasswordAuthentication=yes' > /etc/ssh/sshd_config.d/00-spread.conf`},
 		{"/bin/bash", "-c", fmt.Sprintf("echo root:'%s' | chpasswd", p.options.Password)},
 		{"killall", "-HUP", "sshd"},
 	}

--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -482,6 +482,7 @@ func (p *lxdProvider) serverJSON(name string) (*lxdServerJSON, error) {
 func (p *lxdProvider) tuneSSH(name string) error {
 	cmds := [][]string{
 		{"sed", "-i", `s/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/`, "/etc/ssh/sshd_config"},
+		{"/bin/bash", "-c", `sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config.d/* || true`},
 		{"/bin/bash", "-c", fmt.Sprintf("echo root:'%s' | chpasswd", p.options.Password)},
 		{"killall", "-HUP", "sshd"},
 	}


### PR DESCRIPTION
This fixes the issue that SSH login wouldn't work after a ubuntu-22.04 image is deployed.

While `tuneSSH()` tries to set `PasswordAuthentication` to `yes` in `/etc/ssh/sshd_config`, Ubuntu 22.04 images in LXD have a file `/etc/ssh/sshd_config.d/60-cloudimg-settings.conf` that contains "PasswordAuthentication no", and this file is sourced by `/etc/ssh/sshd_config`.

Fix this by also `sed`ing all files matching `/etc/ssh/sshd_config.d/*`, but ignore failures of this command, as Ubuntu 20.04 and older don't have `/etc/ssh/sshd_config.d` (or files that match the glob above).

Related links: https://superuser.com/a/1828947