### PR TITLE
lxd: select server based on name from result

### DIFF
--- a/spread/export_test.go
+++ b/spread/export_test.go
@@ -38,6 +38,20 @@ func FakeSshDial(f func(network, addr string, config *ssh.ClientConfig) (*ssh.Cl
 	}
 }
 
+type LXDServerJSON = lxdServerJSON
+
+func LXDProviderServerJSON(provider Provider, name string) (*LXDServerJSON, error) {
+	return provider.(*lxdProvider).serverJSON(name)
+}
+
+func FakeLXDList(f func(name string) ([]byte, error)) (restore func()) {
+	oldLxdList := lxdList
+	lxdList = f
+	return func() {
+		lxdList = oldLxdList
+	}
+}
+
 var QemuCmd = qemuCmd
 
 func FakeGoogleProvider(mockApiURL string, p *Project, b *Backend, o *Options) Provider {

--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -457,14 +457,9 @@ func (p *lxdProvider) address(name string) (string, error) {
 }
 
 func (p *lxdProvider) serverJSON(name string) (*lxdServerJSON, error) {
-	var stderr bytes.Buffer
-	cmd := exec.Command("lxc", "list", "--format=json", name)
-	cmd.Stderr = &stderr
-
-	output, err := cmd.Output()
+	output, err := lxdList(name)
 	if err != nil {
-		err = outputErr(stderr.Bytes(), err)
-		return nil, fmt.Errorf("cannot list lxd container: %v", err)
+		return nil, err
 	}
 
 	var sjsons []*lxdServerJSON
@@ -503,6 +498,22 @@ func (p *lxdProvider) tuneSSH(name string) error {
 		}
 	}
 	return nil
+}
+
+var lxdList = lxdListImpl
+
+func lxdListImpl(name string) ([]byte, error) {
+	var stderr bytes.Buffer
+	cmd := exec.Command("lxc", "list", "--format=json", name)
+	cmd.Stderr = &stderr
+
+	output, err := cmd.Output()
+	if err != nil {
+		err = outputErr(stderr.Bytes(), err)
+		return nil, fmt.Errorf("cannot list lxd container: %w", err)
+	}
+
+	return output, nil
 }
 
 func contains(strs []string, s string) bool {

--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -475,13 +475,12 @@ func (p *lxdProvider) serverJSON(name string) (*lxdServerJSON, error) {
 
 	debugf("lxd list output: %# v\n", sjsons)
 
-	if len(sjsons) == 0 {
-		return nil, &lxdNoServerError{name}
+	for _, server := range sjsons {
+		if server.Name == name {
+			return server, nil
+		}
 	}
-	if sjsons[0].Name != name {
-		return nil, fmt.Errorf("lxd returned invalid JSON listing for %q: %s", name, outputErr(output, nil))
-	}
-	return sjsons[0], nil
+	return nil, &lxdNoServerError{name}
 }
 
 func (p *lxdProvider) tuneSSH(name string) error {

--- a/spread/lxd_test.go
+++ b/spread/lxd_test.go
@@ -1,0 +1,63 @@
+package spread_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/spread/spread"
+)
+
+type lxdSuite struct{}
+
+var _ = Suite(&lxdSuite{})
+
+type serverJSONTest struct {
+	insList    string // The instances list from lxc list in JSON format
+	insListErr error  // The error returned when listing instances
+	name       string // The server name to retrieve information from
+	errMsg     string // The expected error message
+}
+
+var serverJSONTests = []serverJSONTest{{
+	insList:    "",
+	insListErr: errors.New("lxc list error"),
+	name:       "foo",
+	errMsg:     "lxc list error",
+}, {
+	insList:    "",
+	insListErr: nil,
+	name:       "foo",
+	errMsg:     "cannot unmarshal lxd list output: unexpected end of JSON input",
+}, {
+	insList:    `[{"name": "foo", "state": {"network": {}}}]`,
+	insListErr: nil,
+	name:       "foo",
+	errMsg:     "",
+}, {
+	insList:    `[{"name": "foo", "state": {"network": {}}}]`,
+	insListErr: nil,
+	name:       "bar",
+	errMsg:     `cannot find lxd server "bar"`,
+}, {
+	insList:    `[{"name": "foo-2", "state": {"network": {}}}, {"name": "foo", "state": {"network": {}}}]`,
+	insListErr: nil,
+	name:       "foo",
+	errMsg:     "",
+}}
+
+func (s *lxdSuite) TestServerJSON(c *C) {
+	for _, tc := range serverJSONTests {
+		restore := spread.FakeLXDList(func(name string) ([]byte, error) { return []byte(tc.insList), tc.insListErr })
+		defer restore()
+
+		lxd := spread.LXD(nil, nil, nil)
+		sjson, err := spread.LXDProviderServerJSON(lxd, tc.name)
+		if tc.errMsg == "" {
+			c.Assert(err, IsNil)
+			c.Check(sjson.Name, Equals, tc.name)
+		} else {
+			c.Assert(err, ErrorMatches, tc.errMsg)
+		}
+	}
+}


### PR DESCRIPTION
Due to prefix or regular expression matching, `lxd list` may list multiple instances. To account for that, instead of assuming it will always return a slice where the first item is the one we're interested in, iterate over the result and pick the one that matches the name exactly. Return an error If no such match exists.

According to lxd documentation, the argument to the list command can be:

* A prefix of the instance name
* A regular expression on the instance name
* A key/value pair referring to a configuration item
* A key/value pair with a shorthand key
* A regular expression matching a config item