### PR TITLE
spread(lxd): work around SSH password authentication disabled by livecd-rootfs

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -23,6 +23,7 @@ backends:
             - ubuntu-20.04-64:
                 image: ubuntu-2004-64-virt-enabled
                 workers: 1
+                storage: 15G
 
     qemu:
         systems:

--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -490,10 +490,9 @@ func (p *lxdProvider) tuneSSH(name string) error {
 		// achieved in a different manner depending on the version of sshd in
 		// the system. Older versions of ssh used a single file.
 		{"sed", "-i", `s/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/`, "/etc/ssh/sshd_config"},
-		// While newer versions have configuration split into a bunch of drop-in
-		// configuration snippets, in which case we provide one that gets loaded
-		// before all others, as the first value observed in the configuration
-		// file prevails (see sshd_config(5)).
+		// If the sshd configuration is split in snippets in /etc/ssh/sshd_config.d,
+		// place the configuration in a 00-* file because the first obtained value
+		// will be used. See sshd_config(5) for details.
 		{"/bin/bash", "-c", `[ -d /etc/ssh/sshd_config.d ] && echo -e "PermitRootLogin yes\nPasswordAuthentication yes" > /etc/ssh/sshd_config.d/00-spread.conf`},
 		{"/bin/bash", "-c", fmt.Sprintf("echo root:'%s' | chpasswd", p.options.Password)},
 		{"killall", "-HUP", "sshd"},

--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -493,7 +493,7 @@ func (p *lxdProvider) tuneSSH(name string) error {
 		// If the sshd configuration is split in snippets in /etc/ssh/sshd_config.d,
 		// place the configuration in a 00-* file because the first obtained value
 		// will be used. See sshd_config(5) for details.
-		{"/bin/bash", "-c", `[ -d /etc/ssh/sshd_config.d ] && echo -e "PermitRootLogin yes\nPasswordAuthentication yes" > /etc/ssh/sshd_config.d/00-spread.conf`},
+		{"/bin/bash", "-c", `if [ -d /etc/ssh/sshd_config.d ]; then echo -e "PermitRootLogin yes\nPasswordAuthentication yes" > /etc/ssh/sshd_config.d/00-spread.conf; fi`},
 		{"/bin/bash", "-c", fmt.Sprintf("echo root:'%s' | chpasswd", p.options.Password)},
 		{"killall", "-HUP", "sshd"},
 	}

--- a/tests/lxd/checks/main/task.yaml
+++ b/tests/lxd/checks/main/task.yaml
@@ -1,4 +1,4 @@
 summary: Ensure it works.
 
 execute: |
-    echo WORKS
+    echo WORKS $SPREAD_SYSTEM

--- a/tests/lxd/spread.yaml
+++ b/tests/lxd/spread.yaml
@@ -4,6 +4,10 @@ backends:
     lxd:
         systems:
             - ubuntu-16.04
+            - ubuntu-18.04
+            - ubuntu-20.04
+            - ubuntu-22.04
+            - ubuntu-24.04
 
 path: /home/test
 

--- a/tests/lxd/task.yaml
+++ b/tests/lxd/task.yaml
@@ -9,8 +9,10 @@ prepare: |
 execute: |
     spread -vv -reuse -resend &> task.out
 
-    grep 'lxd:ubuntu-16.04:checks/main' task.out
-    grep '^WORKS$' task.out
+    for system in ubuntu-16.04 ubuntu-18.04 ubuntu-20.04 ubuntu-22.04; do
+        grep "lxd:${system}:checks/main" task.out
+        grep "^WORKS ${system}\$" task.out
+    done
 
 debug: |
     cat task.out || true


### PR DESCRIPTION
In recent images, livecd-rootfs may be disabling SSH password authentication by default, with the intention that cloud-init would enabled that by placing a higher priority file under /etc/sshd/sshd_config.d/. See https://git.launchpad.net/livecd-rootfs/commit/live-build/ubuntu-cpc/hooks.d/chroot/052-ssh_authentication.chroot?id=480d5b26ea97e0bfebac8aedfa1f2bf7286f027a for reference.

Do the same as cloud-init would a drop a higher priority config overriding relevant SSHD settings.