### PR TITLE
Fix fetching artifacts when sudo -i changes directory

### DIFF
--- a/spread/client.go
+++ b/spread/client.go
@@ -657,7 +657,7 @@ func (c *Client) RecvTar(packDir string, include []string, tar io.Writer) error 
 	var stderr safeBuffer
 	session.Stdout = tar
 	session.Stderr = &stderr
-	cmd := fmt.Sprintf(`cd '%s' && %s/bin/tar cJ --sort=name --ignore-failed-read -- %s`, packDir, c.sudo(), strings.Join(args, " "))
+	cmd := fmt.Sprintf(`%s/bin/tar -C %q -cJ --sort=name --ignore-failed-read -- %s`, c.sudo(), packDir, strings.Join(args, " "))
 	err = c.runCommand(session, cmd, nil, &stderr)
 	if err != nil {
 		return outputErr(stderr.Bytes(), err)


### PR DESCRIPTION
When spread connects to a machine as a non-root user, then it injects calls to
sudo -i to run commands as root. This effectively makes the artifact sending
logic equivalent to this script:

```sh
cd directory
sudo -i tar ...
```

The problem is that sudo -i changes the current working directory back to
/root. Pass -C or --directory= to tar, so that all the files are referenced
relative to the task directory.
