### PR TITLE
Update actions workflow to run in self hosted runners with spread installed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: self-hosted
+    runs-on: '["self-hosted", "spread-enabled"]'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
As spread was moved to Canonical org, it is required to tag the runners which have spread configured to run in google.

In other projects we are using the tag spread-enabled to differentiate the runners with spread and the org runners without it.