### PR TITLE
feat: lxd spawn vm mode

### DIFF
--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"gopkg.in/yaml.v2"
 
 	"golang.org/x/net/context"
 )
@@ -107,7 +108,7 @@ func (p *lxdProvider) Allocate(ctx context.Context, system *System) (Server, err
 		name = p.backend.Location + ":" + name
 	}
 
-	args := []string{"launch", lxdimage, name}
+	args := []string{"launch", lxdimage, name, "--vm"}
 	if !p.options.Reuse {
 		args = append(args, "--ephemeral")
 	}


### PR DESCRIPTION
LXD is launched as container. This is different in terms of behavior from all other modes (qemu, google, linode, ...etc).
This means that tests like docker are run via container in container methods which causes unexpected errors.
This PR proposes to launch LXD in VM mode not as containers to match the behavior.