### PR TITLE
chore: don't import deprecated io/ioutil package

### DIFF
--- a/cmd/humbox/main.go
+++ b/cmd/humbox/main.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -227,7 +227,7 @@ func handler(resp http.ResponseWriter, req *http.Request) {
 }
 
 func decodeRequest(resp http.ResponseWriter, req *http.Request, result interface{}) bool {
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		sendError(resp, requestError{fmt.Errorf("cannot read request body: %v", err)})
 		return false

--- a/cmd/humbox/manager.go
+++ b/cmd/humbox/manager.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base32"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -132,7 +131,7 @@ func (m *Manager) Servers(account *Account) ([]*Server, error) {
 }
 
 func (m *Manager) Reload() error {
-	data, err := ioutil.ReadFile(m.path("setup.yaml"))
+	data, err := os.ReadFile(m.path("setup.yaml"))
 	if err != nil {
 		return fmt.Errorf("cannot read setup file: %v", err)
 	}
@@ -301,7 +300,7 @@ func (m *Manager) reloadServers() error {
 			continue
 		}
 
-		data, err := ioutil.ReadFile(m.path("servers", name, "server.yaml"))
+		data, err := os.ReadFile(m.path("servers", name, "server.yaml"))
 		if err != nil {
 			log.Printf("WARNING: Cannot read server.yaml for server %s: %v", name, err)
 			continue
@@ -474,14 +473,14 @@ func (m *Manager) serverPid(name string) (int, error) {
 		return 0, nil
 	}
 
-	data, err := ioutil.ReadFile(m.path("servers", name, "qemu.pid"))
+	data, err := os.ReadFile(m.path("servers", name, "qemu.pid"))
 	if err != nil && !os.IsNotExist(err) {
 		log.Printf("Cannot read pid of server %s: %v", name, err)
 		return 0, fmt.Errorf("cannot read pid of server %s: %v", name, err)
 	}
 
 	pidstr := string(bytes.TrimSpace(data))
-	data, err = ioutil.ReadFile("/proc/" + pidstr + "/cmdline")
+	data, err = os.ReadFile("/proc/" + pidstr + "/cmdline")
 	if err == nil && strings.Contains(string(data), "\x00-name\x00"+name+"\x00") {
 		pid, err := strconv.Atoi(pidstr)
 		if err != nil {
@@ -577,12 +576,12 @@ func (m *Manager) Allocate(account *Account, image *Image, password string, cust
 	// Write cloud-init seed disk.
 	userdataPath := m.path("servers", server.Name, "user-data")
 	metadataPath := m.path("servers", server.Name, "meta-data")
-	err = ioutil.WriteFile(userdataPath, []byte(fmt.Sprintf(cloudInitUser, password)), 0600)
+	err = os.WriteFile(userdataPath, []byte(fmt.Sprintf(cloudInitUser, password)), 0600)
 	if err != nil {
 		log.Printf("Cannot write user-data for server %s: %v", server.Name, err)
 		return nil, fmt.Errorf("cannot write user-data for server %s: %v", server.Name, err)
 	}
-	err = ioutil.WriteFile(metadataPath, []byte(fmt.Sprintf(cloudInitMeta, server.Name)), 0600)
+	err = os.WriteFile(metadataPath, []byte(fmt.Sprintf(cloudInitMeta, server.Name)), 0600)
 	if err != nil {
 		log.Printf("Cannot write meta-data for server %s: %v", server.Name, err)
 		return nil, fmt.Errorf("cannot write meta-data for server %s: %v", server.Name, err)
@@ -605,7 +604,7 @@ func (m *Manager) Allocate(account *Account, image *Image, password string, cust
 		log.Printf("Cannot generate control data for server %s: %v", server.Name, err)
 		return nil, fmt.Errorf("cannot generate control data for server %s: %v", server.Name, err)
 	}
-	err = ioutil.WriteFile(yamlPath+"~", data, 0600)
+	err = os.WriteFile(yamlPath+"~", data, 0600)
 	if err != nil {
 		log.Printf("Cannot write control data for server %s: %v", server.Name, err)
 		return nil, fmt.Errorf("cannot write control data for server %s: %v", server.Name, err)

--- a/spread/google.go
+++ b/spread/google.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"os"
@@ -932,7 +932,7 @@ func (p *googleProvider) dofl(method, subpath string, params interface{}, result
 			return fmt.Errorf("cannot perform Google request: %v", err)
 		}
 
-		data, err = ungzip(ioutil.ReadAll(resp.Body))
+		data, err = ungzip(io.ReadAll(resp.Body))
 		resp.Body.Close()
 		if err != nil {
 			return fmt.Errorf("cannot read Google response: %v", err)
@@ -988,5 +988,5 @@ func ungzip(data []byte, err error) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("data seems compressed but corrupted")
 	}
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }

--- a/spread/humbox.go
+++ b/spread/humbox.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"os"
@@ -307,7 +307,7 @@ func (p *humboxProvider) dofl(method, subpath string, params interface{}, result
 	}
 	defer resp.Body.Close()
 
-	data, err = ioutil.ReadAll(resp.Body)
+	data, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("cannot read Humbox response: %v", err)
 	}

--- a/spread/linode.go
+++ b/spread/linode.go
@@ -3,7 +3,7 @@ package spread
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -1549,7 +1549,7 @@ func (p *linodeProvider) dofl(params linodeParams, result interface{}, flags doF
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("cannot read Linode response: %v", err)
 	}

--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -382,7 +382,7 @@ func lxdName(system *System) (string, error) {
 		return "", fmt.Errorf("cannot obtain lock on ~/.spread/lxd-count: %v", err)
 	}
 
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return "", fmt.Errorf("cannot read ~/.spread/lxd-count: %v", err)
 	}

--- a/spread/project.go
+++ b/spread/project.go
@@ -3,7 +3,6 @@ package spread
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -639,7 +638,7 @@ func Load(path string) (*Project, error) {
 			if fi, _ := os.Stat(filepath.Dir(tfilename)); !fi.IsDir() {
 				continue
 			}
-			tdata, err := ioutil.ReadFile(tfilename)
+			tdata, err := os.ReadFile(tfilename)
 			if os.IsNotExist(err) {
 				debugf("Skipping %s/%s: task.yaml missing", sname, tname)
 				continue
@@ -701,11 +700,11 @@ func readProject(path string) (filename string, data []byte, err error) {
 	for {
 		filename = filepath.Join(path, "spread.yaml")
 		debugf("Trying to read %s...", filename)
-		data, err = ioutil.ReadFile(filename)
+		data, err = os.ReadFile(filename)
 		if os.IsNotExist(err) {
 			filename = filepath.Join(path, ".spread.yaml")
 			debugf("Trying to read %s...", filename)
-			data, err = ioutil.ReadFile(filename)
+			data, err = os.ReadFile(filename)
 		}
 		if err == nil {
 			logf("Found %s.", filename)

--- a/spread/project_test.go
+++ b/spread/project_test.go
@@ -1,7 +1,6 @@
 package spread_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -128,7 +127,7 @@ func (s *projectSuite) TestLoad(c *C) {
 		if tc.reroot != "" {
 			yaml = append(yaml, []byte("reroot: "+tc.reroot)...)
 		}
-		err = ioutil.WriteFile(filepath.Join(tmpdir, tc.filename), yaml, 0644)
+		err = os.WriteFile(filepath.Join(tmpdir, tc.filename), yaml, 0644)
 		c.Assert(err, IsNil)
 		err = os.MkdirAll(filepath.Join(tmpdir, "tests"), 0755)
 		c.Assert(err, IsNil)

--- a/spread/qemu_test.go
+++ b/spread/qemu_test.go
@@ -1,7 +1,6 @@
 package spread_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +21,7 @@ func makeMockQemuImg(c *C, mockSystemName string) (restore func()) {
 	err := os.MkdirAll(mockQemuDir, 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(mockQemuDir, mockSystemName+".img"), nil, 0644)
+	err = os.WriteFile(filepath.Join(mockQemuDir, mockSystemName+".img"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	realHome := os.Getenv("HOME")

--- a/spread/reuse.go
+++ b/spread/reuse.go
@@ -2,7 +2,7 @@ package spread
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sync"
 	"syscall"
@@ -57,7 +57,7 @@ func OpenReuse(filename string) (r *Reuse, err error) {
 		return nil, fmt.Errorf("cannot open reuse tracking file: %v", err)
 	}
 
-	data, err := ioutil.ReadAll(datafile)
+	data, err := io.ReadAll(datafile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read reuse tracking file: %v", err)
 	}

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -253,7 +252,7 @@ func (r *Runner) prepareContent() (err error) {
 		return nil
 	}
 
-	file, err := ioutil.TempFile("", fmt.Sprintf("spread-content.%d.", os.Getpid()))
+	file, err := os.CreateTemp("", fmt.Sprintf("spread-content.%d.", os.Getpid()))
 	if err != nil {
 		return fmt.Errorf("cannot create temporary content file: %v", err)
 	}


### PR DESCRIPTION
Package io/ioutil was deprecated in go 1.16. The same functionality
is provided by packages io or os, so replace the calls accordingly.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>