### PR TITLE
fix: permit selecting a different tar filter for artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,8 @@ hold it after the job is executed.
 Residual content is fetched whether the job finishes successfully or not,
 and even if some of the provided paths are missing.
 
+By default artifacts are fetched and compressed using `xz`. If this is
+unavailable use the `-tar-filter` flag specifying an option, eg `gzip`.
 
 <a name="lxd"/>
 

--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -31,6 +31,7 @@ var (
 	restore        = flag.Bool("restore", false, "Run only the restore scripts")
 	discard        = flag.Bool("discard", false, "Discard reused servers without running")
 	artifacts      = flag.String("artifacts", "", "Where to store task artifacts")
+	tarFilter      = flag.String("tar-filter", "xz", "Which tar filter to use for artifacts xz|gzip|bz2")
 	seed           = flag.Int64("seed", 0, "Seed for job order permutation")
 	repeat         = flag.Int("repeat", 0, "Number of times to repeat each task")
 	garbageCollect = flag.Bool("gc", false, "Garbage collect backend resources when possible")
@@ -79,6 +80,10 @@ func run() error {
 		}
 	}
 
+	tarfilter, ok := spread.TarFilters[*tarFilter]
+	if !ok {
+		return fmt.Errorf("unknown tar-filter %q", *tarFilter)
+	}
 	options := &spread.Options{
 		Password:       password,
 		Filter:         filter,
@@ -93,6 +98,7 @@ func run() error {
 		Restore:        *restore,
 		Discard:        *discard,
 		Artifacts:      *artifacts,
+		TarFilter:      tarfilter,
 		Seed:           *seed,
 		Repeat:         *repeat,
 		GarbageCollect: *garbageCollect,

--- a/spread/client.go
+++ b/spread/client.go
@@ -635,7 +635,7 @@ func (c *Client) SendTar(tar io.Reader, unpackDir string) error {
 	return nil
 }
 
-func (c *Client) RecvTar(packDir string, include []string, tar io.Writer) error {
+func (c *Client) RecvTar(packDir string, include []string, tarFilter TarFilter, tar io.Writer) error {
 	session, err := c.sshc.NewSession()
 	if err != nil {
 		return err
@@ -657,7 +657,7 @@ func (c *Client) RecvTar(packDir string, include []string, tar io.Writer) error 
 	var stderr safeBuffer
 	session.Stdout = tar
 	session.Stderr = &stderr
-	cmd := fmt.Sprintf(`%s/bin/tar -C %q -cJ --sort=name --ignore-failed-read -- %s`, c.sudo(), packDir, strings.Join(args, " "))
+	cmd := fmt.Sprintf(`%s/bin/tar -C %q -c%s --sort=name --ignore-failed-read -- %s`, c.sudo(), packDir, tarFilter, strings.Join(args, " "))
 	err = c.runCommand(session, cmd, nil, &stderr)
 	if err != nil {
 		return outputErr(stderr.Bytes(), err)


### PR DESCRIPTION
permit working with ubuntu core

fixes: canonical#165

add extra flag `-tar-filter` to select alternative to `xz` which is not available in core base snaps