### PR TITLE
refactor: adjust openstack name case

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Spread
 [LXD backend](#lxd)  
 [QEMU backend](#qemu)  
 [Google backend](#google)  
-[Openstack backend](#openstack)  
+[OpenStack backend](#openstack)
 [Linode backend](#linode)  
 [AdHoc backend](#adhoc)  
 [More on parallelism](#parallelism)  
@@ -914,7 +914,7 @@ recommended to prevent automated manipulation of important machines.
 
 <a name="openstack"/>
 
-## Openstack backend
+## OpenStack backend
 
 This backend allows distributing your tasks to an OpenStack environment. It
 currently only supports version 3 of the OpenStack identity API and the

--- a/spread/export_openstack_test.go
+++ b/spread/export_openstack_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 var (
-	OpenstackName = openstackName
+	OpenStackName = openstackName
 )
 
-func FakeOpenstackImageClient(p Provider, imageClient glanceImageClient) (restore func()) {
+func FakeOpenStackImageClient(p Provider, imageClient glanceImageClient) (restore func()) {
 	opst := p.(*openstackProvider)
 	oldGlanceImageClient := opst.imageClient
 	opst.imageClient = imageClient
@@ -21,7 +21,7 @@ func FakeOpenstackImageClient(p Provider, imageClient glanceImageClient) (restor
 	}
 }
 
-func FakeOpenstackComputeClient(p Provider, computeClient novaComputeClient) (restore func()) {
+func FakeOpenStackComputeClient(p Provider, computeClient novaComputeClient) (restore func()) {
 	opst := p.(*openstackProvider)
 	oldNovaImageClient := opst.computeClient
 	opst.computeClient = computeClient
@@ -30,7 +30,7 @@ func FakeOpenstackComputeClient(p Provider, computeClient novaComputeClient) (re
 	}
 }
 
-func FakeOpenstackGooseClient(p Provider, gooseClient gooseclient.Client) (restore func()) {
+func FakeOpenStackGooseClient(p Provider, gooseClient gooseclient.Client) (restore func()) {
 	opst := p.(*openstackProvider)
 	oldOsClient := opst.osClient
 	opst.osClient = gooseClient
@@ -39,7 +39,7 @@ func FakeOpenstackGooseClient(p Provider, gooseClient gooseclient.Client) (resto
 	}
 }
 
-func FakeOpenstackProvisionTimeout(timeout, retry time.Duration) (restore func()) {
+func FakeOpenStackProvisionTimeout(timeout, retry time.Duration) (restore func()) {
 	oldTimeout := openstackProvisionTimeout
 	oldRetry := openstackProvisionRetry
 	openstackProvisionTimeout = timeout
@@ -50,7 +50,7 @@ func FakeOpenstackProvisionTimeout(timeout, retry time.Duration) (restore func()
 	}
 }
 
-func FakeOpenstackServerBootTimeout(timeout, retry time.Duration) (restore func()) {
+func FakeOpenStackServerBootTimeout(timeout, retry time.Duration) (restore func()) {
 	oldTimeout := openstackServerBootTimeout
 	oldRetry := openstackServerBootRetry
 	openstackServerBootTimeout = timeout
@@ -61,7 +61,7 @@ func FakeOpenstackServerBootTimeout(timeout, retry time.Duration) (restore func(
 	}
 }
 
-func FakeOpenstackSerialOutputTimeout(timeout time.Duration) (restore func()) {
+func FakeOpenStackSerialOutputTimeout(timeout time.Duration) (restore func()) {
 	oldTimeout := openstackSerialOutputTimeout
 	openstackSerialOutputTimeout = timeout
 	return func() {
@@ -69,12 +69,12 @@ func FakeOpenstackSerialOutputTimeout(timeout time.Duration) (restore func()) {
 	}
 }
 
-func OpenstackFindImage(p Provider, name string) (*glance.ImageDetail, error) {
+func OpenStackFindImage(p Provider, name string) (*glance.ImageDetail, error) {
 	opst := p.(*openstackProvider)
 	return opst.findImage(name)
 }
 
-func OpenstackWaitProvision(p Provider, ctx context.Context, serverID, serverName string) error {
+func OpenStackWaitProvision(p Provider, ctx context.Context, serverID, serverName string) error {
 	opst := p.(*openstackProvider)
 	server := &openstackServer{
 		p: opst,
@@ -86,7 +86,7 @@ func OpenstackWaitProvision(p Provider, ctx context.Context, serverID, serverNam
 	return opst.waitProvision(ctx, server)
 }
 
-func OpenstackWaitServerBoot(p Provider, ctx context.Context, serverID, serverName string, serverNetworks []string) error {
+func OpenStackWaitServerBoot(p Provider, ctx context.Context, serverID, serverName string, serverNetworks []string) error {
 	opst := p.(*openstackProvider)
 	server := &openstackServer{
 		p: opst,
@@ -99,6 +99,6 @@ func OpenstackWaitServerBoot(p Provider, ctx context.Context, serverID, serverNa
 	return opst.waitServerBoot(ctx, server)
 }
 
-func NewOpenstackError(gooseError error) error {
+func NewOpenStackError(gooseError error) error {
 	return &openstackError{gooseError}
 }

--- a/spread/openstack.go
+++ b/spread/openstack.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func Openstack(p *Project, b *Backend, o *Options) Provider {
+func OpenStack(p *Project, b *Backend, o *Options) Provider {
 	return &openstackProvider{
 		project: p,
 		backend: b,
@@ -513,7 +513,7 @@ func (p *openstackProvider) address(ctx context.Context, s *openstackServer) (st
 	for {
 		server, err := p.computeClient.GetServer(s.d.Id)
 		if err != nil {
-			return "", fmt.Errorf("cannot get IP address for Openstack server %s: %v", s, &openstackError{err})
+			return "", fmt.Errorf("cannot get IP address for OpenStack server %s: %v", s, &openstackError{err})
 		}
 		// The addresses for a network is map of networks to a list of ip adresses
 		// We are configuring just 1 network address for the network
@@ -535,7 +535,7 @@ func (p *openstackProvider) address(ctx context.Context, s *openstackServer) (st
 		case <-retry.C:
 			debugf("Server %s is taking a while to get IP address...", s)
 		case <-timeout:
-			return "", fmt.Errorf("timeout waiting for Openstack server %s IP address", s)
+			return "", fmt.Errorf("timeout waiting for OpenStack server %s IP address", s)
 		case <-ctx.Done():
 			return "", fmt.Errorf("cannot wait for %s IP address: interrupted", s)
 		}
@@ -639,9 +639,9 @@ func (p *openstackProvider) createMachine(ctx context.Context, system *System) (
 	}
 	if err != nil {
 		if p.removeMachine(ctx, s) != nil {
-			return nil, &FatalError{fmt.Errorf("cannot allocate or deallocate (!) new Openstack server %s: %v", s, err)}
+			return nil, &FatalError{fmt.Errorf("cannot allocate or deallocate (!) new OpenStack server %s: %v", s, err)}
 		}
-		return nil, &FatalError{fmt.Errorf("cannot allocate new Openstack server %s: %v", s, err)}
+		return nil, &FatalError{fmt.Errorf("cannot allocate new OpenStack server %s: %v", s, err)}
 	}
 
 	return s, nil

--- a/spread/openstack_test.go
+++ b/spread/openstack_test.go
@@ -19,12 +19,12 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func newOpenstack() spread.Provider {
+func newOpenStack() spread.Provider {
 	prj := &spread.Project{}
 	b := &spread.Backend{}
 	opts := &spread.Options{}
 
-	return spread.Openstack(prj, b, opts)
+	return spread.OpenStack(prj, b, opts)
 }
 
 type openstackSuite struct{}
@@ -32,17 +32,17 @@ type openstackSuite struct{}
 var _ = Suite(&openstackSuite{})
 
 func (s *openstackSuite) TestTrivial(c *C) {
-	o := newOpenstack()
+	o := newOpenStack()
 	c.Check(o, NotNil)
 }
 
-func (s *openstackSuite) TestOpenstackName(c *C) {
+func (s *openstackSuite) TestOpenStackName(c *C) {
 	restore := spread.FakeTimeNow(func() time.Time {
 		return time.Date(2007, 8, 22, 11, 59, 58, 987654321, time.UTC)
 	})
 	defer restore()
 
-	name := spread.OpenstackName()
+	name := spread.OpenStackName()
 	c.Check(name, Equals, "aug221159-987654")
 }
 
@@ -66,14 +66,14 @@ problems. Please try again later.</p>
 <address>Apache/2.4.29 (Ubuntu) Server at 10.48.7.10 Port 5000</address>
 </body></html>`)
 
-func (s *openstackSuite) TestOpenstackError(c *C) {
-	err1 := spread.NewOpenstackError(opstErr1)
+func (s *openstackSuite) TestOpenStackError(c *C) {
+	err1 := spread.NewOpenStackError(opstErr1)
 	c.Check(err1.Error(), Equals, `request (https://keystone.bos01.canonistack.canonical.com:5000/v3/tokens) returned unexpected status: 404`)
 
-	err2 := spread.NewOpenstackError(opstErr2)
+	err2 := spread.NewOpenStackError(opstErr2)
 	c.Check(err2.Error(), Equals, `request (https://keystone.bos01.canonistack.canonical.com:5000/v3/tokens) returned unexpected status: 503`)
 
-	err3 := spread.NewOpenstackError(errors.New("other error"))
+	err3 := spread.NewOpenStackError(errors.New("other error"))
 	c.Check(err3.Error(), Equals, `other error`)
 }
 
@@ -168,30 +168,30 @@ type openstackFindImageSuite struct {
 var _ = Suite(&openstackFindImageSuite{})
 
 func (s *openstackFindImageSuite) SetUpTest(c *C) {
-	s.opst = newOpenstack()
+	s.opst = newOpenStack()
 	c.Assert(s.opst, NotNil)
 	s.fakeImageClient = &fakeGlanceImageClient{}
 	s.fakeComputeClient = &fakeNovaComputeClient{}
 	s.fakeOsClient = &fakeOsClient{}
 
-	spread.FakeOpenstackImageClient(s.opst, s.fakeImageClient)
-	spread.FakeOpenstackComputeClient(s.opst, s.fakeComputeClient)
-	spread.FakeOpenstackGooseClient(s.opst, s.fakeOsClient)
+	spread.FakeOpenStackImageClient(s.opst, s.fakeImageClient)
+	spread.FakeOpenStackComputeClient(s.opst, s.fakeComputeClient)
+	spread.FakeOpenStackGooseClient(s.opst, s.fakeOsClient)
 }
 
-func (s *openstackFindImageSuite) TestOpenstackFindImageNotFound(c *C) {
+func (s *openstackFindImageSuite) TestOpenStackFindImageNotFound(c *C) {
 	s.fakeImageClient.res = []glance.ImageDetail{
 		{Name: "unreleated"},
 	}
 
-	_, err := spread.OpenstackFindImage(s.opst, "ubuntu-22.04-64")
+	_, err := spread.OpenStackFindImage(s.opst, "ubuntu-22.04-64")
 	c.Check(err, ErrorMatches, `cannot find matching image for "ubuntu-22.04-64"`)
 }
 
-func (s *openstackFindImageSuite) TestOpenstackFindImageErrors(c *C) {
+func (s *openstackFindImageSuite) TestOpenStackFindImageErrors(c *C) {
 	s.fakeImageClient.err = fmt.Errorf("boom")
 
-	_, err := spread.OpenstackFindImage(s.opst, "ubuntu-22.04-64")
+	_, err := spread.OpenStackFindImage(s.opst, "ubuntu-22.04-64")
 	c.Check(err, ErrorMatches, `cannot retrieve images list: boom`)
 }
 
@@ -222,7 +222,7 @@ func makeGlanceImageDetails(imgs []string) []glance.ImageDetail {
 	return out
 }
 
-var fakeOpenstackImageListMadeUp = []string{
+var fakeOpenStackImageListMadeUp = []string{
 	"ubuntu-22.04",
 	"ubuntu-20.04",
 	"fedora-38",
@@ -236,18 +236,18 @@ type openstackFindImageTest struct {
 
 var openstackFindImageTests = []openstackFindImageTest{{
 	imageName:       "ubuntu-14.04",
-	availableImages: fakeOpenstackImageListMadeUp,
+	availableImages: fakeOpenStackImageListMadeUp,
 	expectFind:      false,
 }, {
 	imageName:       "ubuntu-22.04",
-	availableImages: fakeOpenstackImageListMadeUp,
+	availableImages: fakeOpenStackImageListMadeUp,
 	expectFind:      true,
 }}
 
-func (s *openstackFindImageSuite) TestOpenstackFindImage(c *C) {
+func (s *openstackFindImageSuite) TestOpenStackFindImage(c *C) {
 	for _, tc := range openstackFindImageTests {
 		s.fakeImageClient.res = makeGlanceImageDetails(tc.availableImages)
-		idt, err := spread.OpenstackFindImage(s.opst, tc.imageName)
+		idt, err := spread.OpenStackFindImage(s.opst, tc.imageName)
 		if tc.expectFind {
 			c.Check(err, IsNil, Commentf("%s", tc))
 			c.Check(idt.Name, Equals, tc.imageName)
@@ -258,7 +258,7 @@ func (s *openstackFindImageSuite) TestOpenstackFindImage(c *C) {
 	}
 }
 
-var fakeOpenstackImageList = []string{
+var fakeOpenStackImageList = []string{
 	// from real "openstack image list" output but put here unordered
 	"auto-sync/ubuntu-bionic-18.04-amd64-server-20210928-disk1.img",
 	"auto-sync/ubuntu-bionic-18.04-amd64-server-20230530-disk1.img",
@@ -279,29 +279,29 @@ type openstackFindImageComplexTest struct {
 var openstackFindImageComplexTests = []openstackFindImageComplexTest{{
 	// trivial
 	imageName:         "fedora-35",
-	availableImages:   fakeOpenstackImageList,
+	availableImages:   fakeOpenStackImageList,
 	expectedImageName: "fedora-35",
 }, {
 	// simple string match of name
 	imageName:         "ubuntu-22.04",
-	availableImages:   fakeOpenstackImageList,
+	availableImages:   fakeOpenStackImageList,
 	expectedImageName: "auto-sync/ubuntu-22.04-something",
 }, {
 	// complex sorting based on date of the images
 	imageName:         "ubuntu-bionic-18.04-amd64",
-	availableImages:   fakeOpenstackImageList,
+	availableImages:   fakeOpenStackImageList,
 	expectedImageName: "auto-sync/ubuntu-bionic-18.04-amd64-server-20230530-disk1.img",
 }, {
 	// term matching is more flexible than simple substring matching
 	imageName:         "ubuntu-18.04-server",
-	availableImages:   fakeOpenstackImageList,
+	availableImages:   fakeOpenStackImageList,
 	expectedImageName: "auto-sync/ubuntu-bionic-18.04-amd64-server-20230530-disk1.img",
 }}
 
-func (s *openstackFindImageSuite) TestOpenstackFindImageComplex(c *C) {
+func (s *openstackFindImageSuite) TestOpenStackFindImageComplex(c *C) {
 	for _, tc := range openstackFindImageComplexTests {
 		s.fakeImageClient.res = makeGlanceImageDetails(tc.availableImages)
-		idt, err := spread.OpenstackFindImage(s.opst, tc.imageName)
+		idt, err := spread.OpenStackFindImage(s.opst, tc.imageName)
 		if tc.expectedImageName != "" {
 			c.Check(err, IsNil, Commentf("%s", tc))
 			c.Check(idt.Name, Equals, tc.expectedImageName)
@@ -312,7 +312,7 @@ func (s *openstackFindImageSuite) TestOpenstackFindImageComplex(c *C) {
 	}
 }
 
-func (s *openstackFindImageSuite) TestOpenstackWaitProvisionHappy(c *C) {
+func (s *openstackFindImageSuite) TestOpenStackWaitProvisionHappy(c *C) {
 	count := 0
 	s.fakeComputeClient.getServer = func(serverId string) (*nova.ServerDetail, error) {
 		count++
@@ -335,15 +335,15 @@ func (s *openstackFindImageSuite) TestOpenstackWaitProvisionHappy(c *C) {
 		return nil, nil
 	}
 
-	restore := spread.FakeOpenstackProvisionTimeout(100*time.Millisecond, time.Nanosecond)
+	restore := spread.FakeOpenStackProvisionTimeout(100*time.Millisecond, time.Nanosecond)
 	defer restore()
 
-	err := spread.OpenstackWaitProvision(s.opst, context.TODO(), "test-id", "")
+	err := spread.OpenStackWaitProvision(s.opst, context.TODO(), "test-id", "")
 	c.Check(err, IsNil)
 	c.Check(count, Equals, 2)
 }
 
-func (s *openstackFindImageSuite) TestOpenstackWaitProvisionBadStatus(c *C) {
+func (s *openstackFindImageSuite) TestOpenStackWaitProvisionBadStatus(c *C) {
 	count := 0
 	s.fakeComputeClient.getServer = func(serverId string) (*nova.ServerDetail, error) {
 		count++
@@ -359,30 +359,30 @@ func (s *openstackFindImageSuite) TestOpenstackWaitProvisionBadStatus(c *C) {
 		return nil, nil
 	}
 
-	restore := spread.FakeOpenstackProvisionTimeout(100*time.Millisecond, time.Nanosecond)
+	restore := spread.FakeOpenStackProvisionTimeout(100*time.Millisecond, time.Nanosecond)
 	defer restore()
 
-	err := spread.OpenstackWaitProvision(s.opst, context.TODO(), "test-id", "")
+	err := spread.OpenStackWaitProvision(s.opst, context.TODO(), "test-id", "")
 	c.Check(err, ErrorMatches, "cannot use server: status is not active but ERROR")
 	c.Check(count, Equals, 1)
 }
 
-func (s *openstackFindImageSuite) TestOpenstackWaitProvisionTimeout(c *C) {
+func (s *openstackFindImageSuite) TestOpenStackWaitProvisionTimeout(c *C) {
 	s.fakeComputeClient.getServer = func(serverId string) (*nova.ServerDetail, error) {
 		return &nova.ServerDetail{Status: nova.StatusBuild}, nil
 	}
 
-	restore := spread.FakeOpenstackProvisionTimeout(100*time.Millisecond, time.Nanosecond)
+	restore := spread.FakeOpenStackProvisionTimeout(100*time.Millisecond, time.Nanosecond)
 	defer restore()
 
-	err := spread.OpenstackWaitProvision(s.opst, context.TODO(), "", "test-server")
+	err := spread.OpenStackWaitProvision(s.opst, context.TODO(), "", "test-server")
 	c.Check(err, ErrorMatches, "timeout waiting for test-server to provision")
 }
 
-func (s *openstackFindImageSuite) TestOpenstackWaitServerBootSerialHappy(c *C) {
-	restore := spread.FakeOpenstackServerBootTimeout(100*time.Millisecond, time.Nanosecond)
+func (s *openstackFindImageSuite) TestOpenStackWaitServerBootSerialHappy(c *C) {
+	restore := spread.FakeOpenStackServerBootTimeout(100*time.Millisecond, time.Nanosecond)
 	defer restore()
-	restore = spread.FakeOpenstackSerialOutputTimeout(50 * time.Millisecond)
+	restore = spread.FakeOpenStackSerialOutputTimeout(50 * time.Millisecond)
 	defer restore()
 
 	var called int
@@ -400,15 +400,15 @@ func (s *openstackFindImageSuite) TestOpenstackWaitServerBootSerialHappy(c *C) {
 		}
 	}
 
-	err := spread.OpenstackWaitServerBoot(s.opst, context.TODO(), "test-id", "", []string{"net-1"})
+	err := spread.OpenStackWaitServerBoot(s.opst, context.TODO(), "test-id", "", []string{"net-1"})
 	c.Check(err, IsNil)
 	c.Check(called, Equals, 2)
 }
 
-func (s *openstackFindImageSuite) TestOpenstackWaitServerBootSerialTimeout(c *C) {
-	restore := spread.FakeOpenstackServerBootTimeout(100*time.Millisecond, time.Nanosecond)
+func (s *openstackFindImageSuite) TestOpenStackWaitServerBootSerialTimeout(c *C) {
+	restore := spread.FakeOpenStackServerBootTimeout(100*time.Millisecond, time.Nanosecond)
 	defer restore()
-	restore = spread.FakeOpenstackSerialOutputTimeout(50 * time.Millisecond)
+	restore = spread.FakeOpenStackSerialOutputTimeout(50 * time.Millisecond)
 	defer restore()
 
 	s.fakeOsClient.response = func() interface{} {
@@ -417,11 +417,11 @@ func (s *openstackFindImageSuite) TestOpenstackWaitServerBootSerialTimeout(c *C)
 		}
 	}
 
-	err := spread.OpenstackWaitServerBoot(s.opst, context.TODO(), "test-id", "test-server", []string{"net-1"})
+	err := spread.OpenStackWaitServerBoot(s.opst, context.TODO(), "test-id", "test-server", []string{"net-1"})
 	c.Check(err, ErrorMatches, "cannot find ready marker in console output for test-server: timeout reached")
 }
 
-func (s *openstackFindImageSuite) TestOpenstackWaitServerBootSSHHappy(c *C) {
+func (s *openstackFindImageSuite) TestOpenStackWaitServerBootSSHHappy(c *C) {
 	count := 0
 	spread.FakeSshDial(func(network, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
 		count++
@@ -435,32 +435,32 @@ func (s *openstackFindImageSuite) TestOpenstackWaitServerBootSSHHappy(c *C) {
 		return nil, nil
 	})
 
-	restore := spread.FakeOpenstackServerBootTimeout(100*time.Millisecond, time.Nanosecond)
+	restore := spread.FakeOpenStackServerBootTimeout(100*time.Millisecond, time.Nanosecond)
 	defer restore()
-	restore = spread.FakeOpenstackSerialOutputTimeout(50 * time.Millisecond)
+	restore = spread.FakeOpenStackSerialOutputTimeout(50 * time.Millisecond)
 	defer restore()
 
 	// force fallback to SSH
 	s.fakeOsClient.err = fmt.Errorf("serial not supported")
 
-	err := spread.OpenstackWaitServerBoot(s.opst, context.TODO(), "test-id", "", []string{"net-1"})
+	err := spread.OpenStackWaitServerBoot(s.opst, context.TODO(), "test-id", "", []string{"net-1"})
 	c.Check(err, IsNil)
 	c.Check(count, Equals, 2)
 }
 
-func (s *openstackFindImageSuite) TestOpenstackWaitServerBootSSHTimeout(c *C) {
+func (s *openstackFindImageSuite) TestOpenStackWaitServerBootSSHTimeout(c *C) {
 	spread.FakeSshDial(func(network, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
 		return nil, errors.New("connection error")
 	})
 
-	restore := spread.FakeOpenstackServerBootTimeout(100*time.Millisecond, time.Nanosecond)
+	restore := spread.FakeOpenStackServerBootTimeout(100*time.Millisecond, time.Nanosecond)
 	defer restore()
-	restore = spread.FakeOpenstackSerialOutputTimeout(50 * time.Millisecond)
+	restore = spread.FakeOpenStackSerialOutputTimeout(50 * time.Millisecond)
 	defer restore()
 
 	// force fallback to SSH
 	s.fakeOsClient.err = fmt.Errorf("serial not supported")
 
-	err := spread.OpenstackWaitServerBoot(s.opst, context.TODO(), "test-id", "test-server", []string{"net-1"})
+	err := spread.OpenStackWaitServerBoot(s.opst, context.TODO(), "test-id", "test-server", []string{"net-1"})
 	c.Check(err, ErrorMatches, "cannot connect to server test-server: cannot ssh to the allocated instance: timeout reached")
 }

--- a/spread/project.go
+++ b/spread/project.go
@@ -59,12 +59,12 @@ type Backend struct {
 	// Only for qemu so far.
 	Memory Size
 
-	// Only for Linode, Google, Openstack so far.
+	// Only for Linode, Google, OpenStack so far.
 	Plan     string
 	Location string
 	Storage  Size
 
-	// Only for Openstack so far
+	// Only for OpenStack so far
 	Account  string
 	Endpoint string
 	Networks []string
@@ -128,7 +128,7 @@ type System struct {
 	// Only for Linode and Google so far.
 	Storage Size
 
-	// Only for Openstack so far
+	// Only for OpenStack so far
 	Networks []string
 	Groups   []string
 

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -78,7 +78,7 @@ func Start(project *Project, options *Options) (*Runner, error) {
 		case "google":
 			r.providers[bname] = Google(project, backend, options)
 		case "openstack":
-			r.providers[bname] = Openstack(project, backend, options)
+			r.providers[bname] = OpenStack(project, backend, options)
 		case "linode":
 			r.providers[bname] = Linode(project, backend, options)
 		case "lxd":


### PR DESCRIPTION
Adjust the OpenStack name casing consistently across documentation
and code to match official spelling, but keep "openstack" in unexported
names (don't use mixed-case "openStack").