### PR TITLE
fix: revert artifact tar filter back to gzip

### DIFF
--- a/spread/client.go
+++ b/spread/client.go
@@ -657,7 +657,7 @@ func (c *Client) RecvTar(packDir string, include []string, tar io.Writer) error 
 	var stderr safeBuffer
 	session.Stdout = tar
 	session.Stderr = &stderr
-	cmd := fmt.Sprintf(`%s/bin/tar -C %q -cJ --sort=name --ignore-failed-read -- %s`, c.sudo(), packDir, strings.Join(args, " "))
+	cmd := fmt.Sprintf(`%s/bin/tar -C %q -cz --sort=name --ignore-failed-read -- %s`, c.sudo(), packDir, strings.Join(args, " "))
 	err = c.runCommand(session, cmd, nil, &stderr)
 	if err != nil {
 		return outputErr(stderr.Bytes(), err)

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -829,7 +829,7 @@ func (r *Runner) fetchArtifacts(client *Client, job *Job) error {
 	tarr, tarw := io.Pipe()
 
 	var stderr bytes.Buffer
-	cmd := exec.Command("tar", "xJ")
+	cmd := exec.Command("tar", "xz")
 	cmd.Dir = localDir
 	cmd.Stdin = tarr
 	cmd.Stderr = &stderr


### PR DESCRIPTION
permit working with Ubuntu Core

fixes: #165

discussion in #213