### PR TITLE
fix: change the go module name to canonical/spread

### DIFF
--- a/cmd/humbox/main.go
+++ b/cmd/humbox/main.go
@@ -193,7 +193,7 @@ func handler(resp http.ResponseWriter, req *http.Request) {
 
 	if req.URL.Path == "/" {
 		log.Printf("Request by %s to %s %s", req.RemoteAddr, req.Method, req.URL)
-		resp.Header().Set("Location", "http://github.com/snapcore/spread")
+		resp.Header().Set("Location", "http://github.com/canonical/spread")
 		resp.WriteHeader(http.StatusTemporaryRedirect)
 		return
 	}
@@ -390,7 +390,7 @@ func sendError(resp http.ResponseWriter, err error, args ...interface{}) {
 }
 
 func sendNotFound(resp http.ResponseWriter, req *http.Request) {
-	sendError(resp, errNotFound, `path %s unsupported; see the documentation at github.com/snapcore/spread`, req.URL.Path)
+	sendError(resp, errNotFound, `path %s unsupported; see the documentation at github.com/canonical/spread`, req.URL.Path)
 }
 
 func sendBadMethod(resp http.ResponseWriter, req *http.Request) {

--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/niemeyer/pretty"
-	"github.com/snapcore/spread/spread"
+	"github.com/canonical/spread/spread"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/snapcore/spread
+module github.com/canonical/spread
 
 go 1.23.0
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -36,7 +36,7 @@ exclude:
     - tests/.spread-reuse.yaml
     - $CACHE_DISABLED
 
-path: /home/test/src/github.com/snapcore/spread
+path: /home/test/src/github.com/canonical/spread
 
 suites:
     tests/: 

--- a/spread/client.go
+++ b/spread/client.go
@@ -356,9 +356,9 @@ func (c *Client) runPart(script string, dir string, env *Environment, mode outpu
 	buf.WriteString(rc(false, "REBOOT() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<REBOOT>' || echo \"<REBOOT $1>\"; exit 213; }\n"))
 	buf.WriteString(rc(false, "ERROR() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<ERROR>' || echo \"<ERROR $@>\"; exit 213; }\n"))
 	// We are not using pipes here, see:
-	//  https://github.com/snapcore/spread/pull/64
+	//  https://github.com/canonical/spread/pull/64
 	// We also run it in a subshell, see
-	//  https://github.com/snapcore/spread/pull/67
+	//  https://github.com/canonical/spread/pull/67
 	buf.WriteString(rc(true, "MATCH() ( { set +xu; } 2> /dev/null; [ ${#@} -gt 0 ] || { echo \"error: missing regexp argument\"; return 1; }; local stdin=\"$(cat)\"; grep -q -E \"$@\" <<< \"$stdin\" || { res=$?; echo \"grep error: pattern not found, got:\n$stdin\">&2; if [ $res != 1 ]; then echo \"unexpected grep exit status: $res\"; fi; return 1; }; )\n"))
 	buf.WriteString(rc(true, "NOMATCH() ( { set +xu; } 2> /dev/null; [ ${#@} -gt 0 ] || { echo \"error: missing regexp argument\"; return 1; }; local stdin=\"$(cat)\"; if echo \"$stdin\" | grep -q -E \"$@\"; then echo \"NOMATCH pattern='$@' found in:\n$stdin\">&2; return 1; fi; )\n"))
 	buf.WriteString("export DEBIAN_FRONTEND=noninteractive\n")

--- a/spread/client_test.go
+++ b/spread/client_test.go
@@ -8,7 +8,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/spread/spread"
+	"github.com/canonical/spread/spread"
 )
 
 type clientSuite struct{}

--- a/spread/google_test.go
+++ b/spread/google_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/snapcore/spread/spread"
+	"github.com/canonical/spread/spread"
 
 	. "gopkg.in/check.v1"
 )

--- a/spread/lxd_test.go
+++ b/spread/lxd_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/spread/spread"
+	"github.com/canonical/spread/spread"
 )
 
 type lxdSuite struct{}

--- a/spread/openstack.go
+++ b/spread/openstack.go
@@ -263,7 +263,7 @@ func (p *openstackProvider) findImage(imageName string) (*glance.ImageDetail, er
 	var lastCreatedDate time.Time
 
 	// TODO: consider using an image cache just like the google backend
-	// (https://github.com/snapcore/spread/pull/175 needs to be fixed first)
+	// (https://github.com/canonical/spread/pull/175 needs to be fixed first)
 	images, err := p.imageClient.ListImagesDetail()
 	if err != nil {
 		return nil, fmt.Errorf("cannot retrieve images list: %v", &openstackError{err})

--- a/spread/openstack_test.go
+++ b/spread/openstack_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-goose/goose/v5/nova"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/snapcore/spread/spread"
+	"github.com/canonical/spread/spread"
 
 	. "gopkg.in/check.v1"
 )

--- a/spread/project_test.go
+++ b/spread/project_test.go
@@ -8,8 +8,8 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/snapcore/spread/spread"
-	"github.com/snapcore/spread/spread/testutil"
+	"github.com/canonical/spread/spread"
+	"github.com/canonical/spread/spread/testutil"
 )
 
 func Test(t *testing.T) { TestingT(t) }

--- a/spread/qemu_test.go
+++ b/spread/qemu_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/snapcore/spread/spread"
+	"github.com/canonical/spread/spread"
 
 	. "gopkg.in/check.v1"
 )

--- a/spread/testutil/reindent_test.go
+++ b/spread/testutil/reindent_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/spread/spread/testutil"
+	"github.com/canonical/spread/spread/testutil"
 )
 
 type S struct{}

--- a/tests/repack/spread.yaml
+++ b/tests/repack/spread.yaml
@@ -7,7 +7,7 @@ backends:
 
 environment:
     GOPATH: /gopath
-    GOPKG: github.com/snapcore/spread
+    GOPKG: github.com/canonical/spread
     PATH: $GOPATH/bin:$PATH
     DELTA_REF: 08dbc8b
     DELTA_PREFIX: spread-$DELTA_REF/


### PR DESCRIPTION
Fixes #240, which was introduced with #238