### PR TITLE
minor toc formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Spread
 
 [Why?](#why)  
 [The cascading matrix](#matrix)  
-[Install](#install)
+[Install](#install)  
 [Hello world](#hello-world)  
 [Environments](#environments)  
 [Variants](#variants)  


### PR DESCRIPTION
`install` and `hello world` appear on the same line in github preview. this should fix it