### PR TITLE
docs: fix outdated link to binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ backend:system:suite/task:variant
 Please install `spread` using Go install method:
 
 ```shell
-go install github.com/canonical/spread/cmd/spread@latest
+go install github.com/snapcore/spread/cmd/spread@latest
 ```
 
 <a name="hello-world"/>


### PR DESCRIPTION
The changed performed in [893d5d5](https://github.com/canonical/spread/pull/238/commits/893d5d5c6b56130a5c33cbc84b9ea5c74c1dedfa) needs to be reverted, the link is back to `snapcore`.