### PR TITLE
feat: bundle lxc client and add lxd plug

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,6 +9,10 @@ description: |
     where, what to do before and after it runs, and how to duplicate jobs
     with minor variations without copy & paste.
 
+    To use the LXD backend, connect the lxd interface:
+
+       sudo snap connect spread:lxd lxd:lxd
+
 confinement: strict
 grade: stable
 base: core24
@@ -22,6 +26,7 @@ apps:
           - home
           - network
           - network-bind
+          - lxd
 
 parts:
     spread:
@@ -34,3 +39,13 @@ parts:
         override-pull: |
           craftctl default
           craftctl set version="$(date +"%Y.%m.%d")-g$(git rev-parse --short HEAD)"
+
+    lxd:
+        source: https://github.com/canonical/lxd
+        source-type: git
+        source-depth: 1
+        source-branch: stable-5.21
+        plugin: nil
+        override-build: |
+          mkdir "${CRAFT_PART_INSTALL}/bin"
+          go build -o "${CRAFT_PART_INSTALL}/bin/lxc" ./lxc


### PR DESCRIPTION
Enable strictly confined spread snap to communicate with the host LXD
server via the lxd interface. This allows the snap-packaged spread to
execute jobs using the LXD backend.